### PR TITLE
Feat : 모임 페이지 페이지네이션 및 API 호출 구현

### DIFF
--- a/src/app/gathering/[id]/page.tsx
+++ b/src/app/gathering/[id]/page.tsx
@@ -1,27 +1,21 @@
 'use client';
 
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
+import { useGatheringStore } from '@/store/useGatheringStore';
 import PageContainer from '@/components/@shared/layout/PageContainer';
 import Loading from '@/components/@shared/loading/Loading';
-import AnotherGatherings from '@/components/gatheringDetail/AnotherGatherings';
 import GatheringDetailCard from '@/components/gatheringDetail/GatheringDetailCard';
 import ParticipantList from '@/components/gatheringDetail/ParticipantList';
 import CommentsContainer from '@/components/gatheringDetail/comment/CommentsContainer';
-import {
-  useGetGathering,
-  useGetGatheringDetail,
-} from '@/hooks/reactQuery/useGetGathering';
+import { useGetGatheringDetail } from '@/hooks/reactQuery/useGetGathering';
 import { useGetGatheringMember } from '@/hooks/reactQuery/useGetGatheringMember';
 
 export default function GatheringDetailPage() {
   const { id } = useParams();
+  const router = useRouter();
   const { gatheringMember } = useGetGatheringMember(id);
-  const { gathering } = useGetGathering();
+  const { selectedGathering } = useGatheringStore();
   const { gatheringDetail, isLoading, showLoading } = useGetGatheringDetail(id);
-  const findDetailGathering = gathering.find(
-    (data: { gatheringId: number }) => data.gatheringId === Number(id)
-  );
-  if (!findDetailGathering) return <div>임시 오류처리</div>;
 
   if (showLoading) return <Loading isLoading={isLoading} />;
 
@@ -36,30 +30,23 @@ export default function GatheringDetailPage() {
       representAchievement: [''],
     });
   }
-
-  const leaderAnotherGathering = gathering.slice(0, 2);
-  const dateTimeAntherGathering = gathering
-    .filter(
-      (data: { dateTime: string }) =>
-        data.dateTime === findDetailGathering.dateTime
-    )
-    .slice(0, 2);
+  if (gatheringDetail.gatheringId !== selectedGathering.gatheringId) {
+    router.replace('/not-found');
+    return null;
+  }
   return (
     <PageContainer>
-      <GatheringDetailCard
-        list={findDetailGathering}
-        detail={gatheringDetail}
-      />
+      <GatheringDetailCard list={selectedGathering} detail={gatheringDetail} />
       <ParticipantList gatheringMember={gatheringMember} />
       <CommentsContainer id={id} leaderCheck={gatheringMember[0].nickName} />
-      <AnotherGatherings
+      {/* <AnotherGatherings
         title={`${gatheringMember[0].nickName}님이 만든 모임`}
         gatherings={leaderAnotherGathering}
       />
       <AnotherGatherings
         title="똑같은 일정 다른 모임"
         gatherings={dateTimeAntherGathering}
-      />
+      /> */}
     </PageContainer>
   );
 }

--- a/src/app/gathering/page.tsx
+++ b/src/app/gathering/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useQueryStringStore } from '@/store/useQueryStringStore';
 import CountListValue from '@/components/@shared/cardList/CountListValue';
 import GatheringCardContainer from '@/components/@shared/cardList/GatheringCardContainer';
 import SortDropdown from '@/components/@shared/cardList/SortDropdown';
@@ -11,13 +12,31 @@ import FilterContainer from '@/components/@shared/layout/FilterContainer';
 import PageContainer from '@/components/@shared/layout/PageContainer';
 import SortContainer from '@/components/@shared/layout/SortContainer';
 import Loading from '@/components/@shared/loading/Loading';
+import Pagination from '@/components/@shared/pagination/Pagination';
 import SearchBar from '@/components/@shared/search/SearchBar';
 import { useGetGathering } from '@/hooks/reactQuery/useGetGathering';
+import { usePagination } from '@/hooks/usePagination';
 
 export default function GatheringPage() {
-  const { gathering, isLoading, showLoading } = useGetGathering();
+  const [page, setPage] = useState(0);
   const [sort, setSort] = useState('최신순');
   const sortList = ['최신순', '마감순', '참여순'];
+  const sortLabels: Record<string, string> = {
+    최신순: 'dataTime',
+    마감순: 'registrationEnd',
+    참여순: 'participantCount',
+  };
+  const { largeDistrict, middleDistrict } = useQueryStringStore();
+  const { gathering, isLoading, showLoading } = useGetGathering(
+    '',
+    page,
+    10,
+    sortLabels[sort],
+    largeDistrict,
+    middleDistrict
+  );
+  const totalItems = gathering ? gathering.length : 0;
+  const { totalPages } = usePagination(page, totalItems);
 
   if (showLoading) return <Loading isLoading={isLoading} />;
   return (
@@ -29,10 +48,15 @@ export default function GatheringPage() {
         <MapNavigation target="gathering" />
       </FilterContainer>
       <SortContainer>
-        <CountListValue value={gathering.length} />
+        <CountListValue value={totalItems} />
         <SortDropdown sort={sort} sortList={sortList} sortChange={setSort} />
       </SortContainer>
       <GatheringCardContainer data={gathering} />
+      <Pagination
+        currentPage={page}
+        totalPages={totalPages}
+        onChange={setPage}
+      />
     </PageContainer>
   );
 }

--- a/src/app/room/page.tsx
+++ b/src/app/room/page.tsx
@@ -49,7 +49,7 @@ export default function RoomPage() {
         <MapNavigation target="room" />
       </FilterContainer>
       <SortContainer>
-        <CountListValue value={theme.length} />
+        <CountListValue value={totalItems} />
         <SortDropdown sort={sort} sortList={sortList} sortChange={setSort} />
       </SortContainer>
       <RoomCardContainer data={theme} />

--- a/src/axios/gathering.ts
+++ b/src/axios/gathering.ts
@@ -2,10 +2,25 @@ import { toast } from 'react-toastify';
 import axios from 'axios';
 import { API_PATH } from '@/axios/path.config';
 
-export const GetGathering = async () => {
+interface GetGatheringProps {
+  keyword: string;
+  page: number;
+  limit: number;
+  sort: string;
+  state: string;
+  city: string;
+}
+export const GetGathering = async ({
+  keyword,
+  page,
+  limit,
+  sort,
+  state,
+  city,
+}: GetGatheringProps) => {
   try {
     const res = await axios.get(
-      `${API_PATH.gathering.default}?sortBy=dateTime&limit=10&offset=0`
+      `${API_PATH.gathering.default}?sortBy=${sort}${keyword !== '' ? `&keyword=${keyword}` : ''}${state !== '시.도' ? `&state=${state}` : ''}${city !== '시.군.구' ? `&city=${city}` : ''}&limit=${limit}&offset=${page}`
     );
     return res;
   } catch (error) {

--- a/src/components/@shared/cardList/GatheringCard.tsx
+++ b/src/components/@shared/cardList/GatheringCard.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import { useGatheringStore } from '@/store/useGatheringStore';
 import AddressAndLevel from '@/components/@shared/cardList/AddressAndLevel';
 import DateAndParticipant from '@/components/@shared/cardList/DateAndParticipant';
 import TagAndPlaytime from '@/components/@shared/cardList/TagAndPlaytime';
@@ -13,6 +14,7 @@ interface GatheringCardProps {
 }
 
 export default function GatheringCard({ gathering }: GatheringCardProps) {
+  const { setSelectedGathering } = useGatheringStore();
   return (
     <div
       key={gathering.gatheringId}
@@ -31,7 +33,10 @@ export default function GatheringCard({ gathering }: GatheringCardProps) {
           <Image src={HeartLine} alt="heart" width={32} height={32} />
         </button>
       </div>
-      <Link href={`/gathering/${gathering.gatheringId}`}>
+      <Link
+        href={`/gathering/${gathering.gatheringId}`}
+        onClick={() => setSelectedGathering(gathering)}
+      >
         <div className="ml-5 flex h-[212px] w-[322px] flex-col justify-between">
           <div className="flex flex-col gap-3">
             <TagAndPlaytime

--- a/src/components/@shared/cardList/GatheringCardContainer.tsx
+++ b/src/components/@shared/cardList/GatheringCardContainer.tsx
@@ -1,4 +1,5 @@
 import GatheringCard from '@/components/@shared/cardList/GatheringCard';
+import EmptySearchResult from '@/components/search/EmptySearchResult';
 import { GatheringDTO } from '@/types/gathering/gathering.type';
 
 interface GatheringCardContainerProps {
@@ -9,11 +10,14 @@ export default function GatheringCardContainer({
   data,
 }: GatheringCardContainerProps) {
   return (
-    <div className="mt-6 grid grid-cols-2 gap-5">
-      {data &&
-        data.map((gathering) => (
-          <GatheringCard key={gathering.gatheringId} gathering={gathering} />
-        ))}
-    </div>
+    <>
+      <div className="mt-6 grid grid-cols-2 gap-5">
+        {data &&
+          data.map((gathering) => (
+            <GatheringCard key={gathering.gatheringId} gathering={gathering} />
+          ))}
+      </div>
+      {data && data.length === 0 && <EmptySearchResult />}
+    </>
   );
 }

--- a/src/components/@shared/cardList/RoomCardContainer.tsx
+++ b/src/components/@shared/cardList/RoomCardContainer.tsx
@@ -1,4 +1,5 @@
 import RoomCard from '@/components/@shared/cardList/RoomCard';
+import EmptySearchResult from '@/components/search/EmptySearchResult';
 import { RoomDTO } from '@/types/room/room.types';
 
 interface RoomCardContainerProps {
@@ -11,11 +12,18 @@ export default function RoomCardContainer({
   reviewCheck,
 }: RoomCardContainerProps) {
   return (
-    <div className="mt-6 grid grid-cols-2 gap-5">
-      {data &&
-        data.map((room) => (
-          <RoomCard key={room.themeId} room={room} reviewCheck={reviewCheck} />
-        ))}
-    </div>
+    <>
+      <div className="mt-6 grid grid-cols-2 gap-5">
+        {data &&
+          data.map((room) => (
+            <RoomCard
+              key={room.themeId}
+              room={room}
+              reviewCheck={reviewCheck}
+            />
+          ))}
+      </div>
+      {data && data.length === 0 && <EmptySearchResult />}
+    </>
   );
 }

--- a/src/components/@shared/pagination/Pagination.tsx
+++ b/src/components/@shared/pagination/Pagination.tsx
@@ -27,7 +27,7 @@ export default function Pagination({
     }
   }
 
-  return (
+  return range.length !== 0 ? (
     <div className="flex items-center gap-1 justify-center my-20">
       <button
         type="button"
@@ -74,5 +74,5 @@ export default function Pagination({
         />
       </button>
     </div>
-  );
+  ) : null;
 }

--- a/src/components/roomDetail/RoomDetailCard.tsx
+++ b/src/components/roomDetail/RoomDetailCard.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 import { useThemeStore } from '@/store/useThemeStore';
 import AddressAndLevel from '@/components/@shared/cardList/AddressAndLevel';
 import ReviewAndRating from '@/components/@shared/cardList/ReviewAndRating';
@@ -16,6 +17,7 @@ interface RoomDetailCardProps {
 }
 
 export default function RoomDetailCard({ id }: RoomDetailCardProps) {
+  const router = useRouter();
   const { selectedTheme } = useThemeStore();
   const { themeDetail, isLoading, showLoading } = useGetThemeDetail(id);
   const detail = themeDetail;
@@ -23,6 +25,10 @@ export default function RoomDetailCard({ id }: RoomDetailCardProps) {
 
   if (showLoading) return <Loading isLoading={isLoading} />;
 
+  if (themeDetail.themeId !== selectedTheme.themeId) {
+    router.replace('/not-found');
+    return null;
+  }
   return (
     <div className="flex h-[460px] justify-between">
       <Image

--- a/src/components/roomDetail/RoomDetailGatherings.tsx
+++ b/src/components/roomDetail/RoomDetailGatherings.tsx
@@ -32,7 +32,7 @@ export default function RoomDetailGatherings({
         </Link>
       </div>
 
-      <div className="mt-6 flex justify-between">
+      <div className="mt-6">
         <GatheringCardContainer data={filteredGatherings} />
       </div>
     </>

--- a/src/components/search/EmptySearchResult.tsx
+++ b/src/components/search/EmptySearchResult.tsx
@@ -1,0 +1,23 @@
+import Image from 'next/image';
+import SearchNotFound from '@/public/images/error/search.png';
+
+export default function EmptySearchResult() {
+  return (
+    <div className="flex justify-center items-center flex-col border-2 border-card rounded-3xl pb-5">
+      <p className="font-normal text-[64px] tracking-[0.31em] mb-5">
+        NOT FOUND
+      </p>
+      <Image
+        src={SearchNotFound}
+        alt="검색 결과 없음"
+        width={200}
+        height={200}
+        priority
+        quality={100}
+      />
+      <p className="font-normal text-2xl/[34px] tracking-[-2.5%]">
+        열쇠를 찾지 못했어요.
+      </p>
+    </div>
+  );
+}

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useRef, useState } from 'react';
-import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
 import { useQueryStringStore } from '@/store/useQueryStringStore';
 import 'swiper/css';
@@ -12,11 +11,11 @@ import { Swiper, SwiperClass, SwiperSlide } from 'swiper/react';
 import { Swiper as SwiperType } from 'swiper/types';
 import GatheringCard from '@/components/@shared/cardList/GatheringCard';
 import RoomCard from '@/components/@shared/cardList/RoomCard';
+import EmptySearchResult from '@/components/search/EmptySearchResult';
 import { useGetGathering } from '@/hooks/reactQuery/useGetGathering';
 import { useGetTheme } from '@/hooks/reactQuery/useGetTheme';
 import { GatheringDTO } from '@/types/gathering/gathering.type';
 import { RoomDTO } from '@/types/room/room.types';
-import SearchNotFound from '@/public/images/error/search.png';
 
 export default function SearchResults() {
   const searchParams = useSearchParams();
@@ -34,7 +33,14 @@ export default function SearchResults() {
     largeDistrict,
     middleDistrict
   );
-  const { gathering } = useGetGathering();
+  const { gathering } = useGetGathering(
+    keyword,
+    page,
+    4,
+    'dateTime',
+    largeDistrict,
+    middleDistrict
+  );
   return (
     <>
       <h2 className="font-semibold text-[32px]/[42px] tracking-[-2.5%] mt-[52px]">
@@ -58,24 +64,7 @@ export default function SearchResults() {
               <RoomCard room={room} />
             </SwiperSlide>
           ))}
-        {theme && theme.length === 0 && (
-          <div className="flex justify-center items-center flex-col">
-            <p className="font-normal text-[64px] tracking-[0.31em] mb-5">
-              NOT FOUND
-            </p>
-            <Image
-              src={SearchNotFound}
-              alt="검색 결과 없음"
-              width={200}
-              height={200}
-              priority
-              quality={100}
-            />
-            <p className="font-normal text-2xl/[34px] tracking-[-2.5%]">
-              열쇠를 찾지 못했어요.
-            </p>
-          </div>
-        )}
+        {theme && theme.length === 0 && <EmptySearchResult />}
       </Swiper>
       <h2 className="font-semibold text-[32px]/[42px] tracking-[-2.5%] mt-[52px]">
         모임
@@ -98,6 +87,7 @@ export default function SearchResults() {
               <GatheringCard gathering={data} />
             </SwiperSlide>
           ))}
+        {gathering && gathering.length === 0 && <EmptySearchResult />}
       </Swiper>
     </>
   );

--- a/src/hooks/reactQuery/useGetGathering.ts
+++ b/src/hooks/reactQuery/useGetGathering.ts
@@ -4,10 +4,17 @@ import { useQuery } from '@tanstack/react-query';
 import { GetGathering, GetGatheringDetail } from '@/axios/gathering';
 import { useShowLoading } from '@/hooks/useShowLoading';
 
-export const useGetGathering = () => {
+export const useGetGathering = (
+  keyword: string,
+  page: number,
+  limit: number,
+  sort: string,
+  state: string,
+  city: string
+) => {
   const { data, isLoading, error } = useQuery({
-    queryKey: ['gathering'],
-    queryFn: () => GetGathering(),
+    queryKey: ['gathering', keyword, page, limit, sort, state, city],
+    queryFn: () => GetGathering({ keyword, page, limit, sort, state, city }),
     retry: false,
     staleTime: 1000 * 60 * 5,
   });
@@ -19,7 +26,7 @@ export const useGetGathering = () => {
 
 export const useGetGatheringDetail = (id: string | string[]) => {
   const { data, isLoading, error } = useQuery({
-    queryKey: ['gatheringDetail'],
+    queryKey: ['gatheringDetail', id],
     queryFn: () => GetGatheringDetail(id),
     retry: false,
     staleTime: 1000 * 60 * 5,

--- a/src/hooks/reactQuery/useGetTheme.ts
+++ b/src/hooks/reactQuery/useGetTheme.ts
@@ -44,7 +44,7 @@ export const useGetTheme = (
 
 export const useGetThemeDetail = (id: string | string[]) => {
   const { data, isLoading, error } = useQuery({
-    queryKey: ['themeDetail'],
+    queryKey: ['themeDetail', id],
     queryFn: () => GetThemeDetail(id),
     retry: false,
     staleTime: 1000 * 60 * 5,

--- a/src/store/useGatheringStore.ts
+++ b/src/store/useGatheringStore.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { GatheringDTO } from '@/types/gathering/gathering.type';
+
+interface State {
+  selectedGathering: any;
+}
+
+interface Actions {
+  setSelectedGathering: (selectedGathering: GatheringDTO['get']) => void;
+}
+
+export const useGatheringStore = create<State & Actions>()(
+  persist(
+    (set) => ({
+      selectedGathering: null,
+      setSelectedGathering: (gathering) =>
+        set({ selectedGathering: gathering }),
+    }),
+    { name: 'selected-gathering' }
+  )
+);


### PR DESCRIPTION
## ✏️ 작업 내용 요약

> 이번 PR에서 작업한 내용을 요약해주세요

- 모임 페이지 페이지네이션 및 API 호출 구현
- 검색 페이지 모임 연동
- 사용자가 임의로 페이지 이동 시 not-found 연결

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 테스트 후 오류 발견 시 공유 부탁드립니다.

## 📷 스크린샷 (선택)
![#1 모임페이지 api 호출 구현](https://github.com/user-attachments/assets/ca048da2-a87c-4805-948b-be850d835e20)
![#3 모임 검색 연동](https://github.com/user-attachments/assets/c83778ca-d4b9-46ec-8baf-5c12380a7175)
![#2 임의로 이동시 강제 리디렉트](https://github.com/user-attachments/assets/2451d848-c2bd-4951-b557-d067d6cd3f18)
