### PR TITLE
Fix : 페이지네이션 오류 && 장르 key 오류 해결

### DIFF
--- a/src/components/@shared/cardList/TagAndPlaytime.tsx
+++ b/src/components/@shared/cardList/TagAndPlaytime.tsx
@@ -10,9 +10,9 @@ export default function TagAndPlaytime({ tag, playtime }: TagAndPlaytimeProps) {
   return (
     <div className="flex justify-between">
       <div className="flex gap-1">
-        {tag.map((genre) => (
+        {tag.map((genre, idx) => (
           <p
-            key={genre}
+            key={idx}
             className="flex gap-[2px] rounded-full bg-white px-2 py-1 text-base font-semibold text-tag"
           >
             <span>#</span>

--- a/src/components/@shared/pagination/Pagination.tsx
+++ b/src/components/@shared/pagination/Pagination.tsx
@@ -50,7 +50,7 @@ export default function Pagination({
           </span>
         ) : (
           <button
-            key={item}
+            key={idx}
             type="button"
             onClick={() => onChange(Number(item))}
             className={`font-semibold text-2xl tracking-[-2.5%] ${currentPage === item ? 'text-card' : 'text-setfont hover:text-card'}`}

--- a/src/components/gatheringDetail/AnotherGatherings.tsx
+++ b/src/components/gatheringDetail/AnotherGatherings.tsx
@@ -14,9 +14,7 @@ export default function AnotherGatherings({
     <div className="mt-14">
       <p className="ml-1 text-2xl font-semibold text-white mb-6">{title}</p>
       <div>
-        <div className="flex justify-between">
-          <GatheringCardContainer data={gatherings} />
-        </div>
+        <GatheringCardContainer data={gatherings} />
       </div>
     </div>
   );


### PR DESCRIPTION
## ✏️ 작업 내용 요약

> 이번 PR에서 작업한 내용을 요약해주세요

- 방탈출 목록 페이지에서 장르 key가 겹치는 경우 콘솔 에러가 뜨는 문제 해결
- 페이지네이션에서 중복된 값이 나오는 문제 해결
- 모임 상세페이지 디자인적 오류 해결

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- x

## 📷 스크린샷 (선택)
