### PR TITLE
Fix : 방탈출 상세 페이지에서 모임 생성 시 themeId 안 들어가는 오류 해결

### DIFF
--- a/src/components/@shared/modal/AddGathering/AddGatheringModal.tsx
+++ b/src/components/@shared/modal/AddGathering/AddGatheringModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import AddGatheringButton from '@/components/@shared/modal/AddGathering/AddGatheringButton';
 import AddGatheringCapacity from '@/components/@shared/modal/AddGathering/AddGatheringCapacity';
 import AddGatheringLocation from '@/components/@shared/modal/AddGathering/AddGatheringLocation';
@@ -35,6 +35,13 @@ export default function AddGatheringModal({
     setValue,
     formState: { errors },
   } = usePostGatheringForm(mutate, onClose);
+
+  useEffect(() => {
+    if (isOpen && themeIdProps) {
+      setValue('themeId', themeIdProps, { shouldValidate: true });
+    }
+  }, [isOpen, themeIdProps, setValue]);
+
   return (
     <Modal
       isOpen={isOpen}
@@ -46,9 +53,11 @@ export default function AddGatheringModal({
         <AddGatheringSearchBar
           search={search}
           searchChange={setSearch}
-          themeId={themeIdProps ?? watch('themeId')}
+          themeId={watch('themeId')}
           themeIdChange={(themeId) =>
-            setValue('themeId', themeId, { shouldValidate: true })
+            setValue('themeId', themeId, {
+              shouldValidate: true,
+            })
           }
           register={register}
           errors={errors}

--- a/src/components/roomDetail/RoomDetailCard.tsx
+++ b/src/components/roomDetail/RoomDetailCard.tsx
@@ -133,12 +133,8 @@ export default function RoomDetailCard({ id }: RoomDetailCardProps) {
         </div>
         <RoomDetailStroy
           story={detail.story}
-          themeNameProps={
-            themeDetail.themeId !== selectedTheme.themeId
-              ? 0
-              : selectedTheme.themeName
-          }
-          themeIdProps={themeDetail.themeId}
+          themeNameProps={selectedTheme.themeName}
+          themeIdProps={selectedTheme.themeId}
         />
       </div>
     </div>


### PR DESCRIPTION
## ✏️ 작업 내용 요약

> 이번 PR에서 작업한 내용을 요약해주세요

- 방탈출 상세 페이지에서 모임 생성 시 themeId 안 들어가는 오류 해결

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 추가로 오류가 발견되면 공유 부탁드립니다.

## 📷 스크린샷 (선택)
![#7 모임 만들기 themeId 오류 수정](https://github.com/user-attachments/assets/c25cea79-5c54-4439-a097-3cf5b08a2df3)
